### PR TITLE
text: do not render internal links in text mode

### DIFF
--- a/xml2rfc/writers/text.py
+++ b/xml2rfc/writers/text.py
@@ -1648,7 +1648,10 @@ class TextWriter(BaseV3Writer):
             self.warn(e, "Expected the 'target' attribute to have a value, but found %s" % (etree.tostring(e), ))
         if   brackets == 'none':
             if e.text and target:
-                target = "(%s)" % target
+                if target[0] == '#':
+                    target = ""
+                else:
+                    target = "(%s)" % target
         elif brackets == 'angle':
             target = "<%s>" % target                
         else:


### PR DESCRIPTION
Avoids useless "... (#target) ..." link-like constructs in text output mode

Fixes bug #1195

This is on the level of 'It works for me' I don't know if something more sinister is necessary for this to be complete.